### PR TITLE
Add "All files (*.*)" to OpenFileDialog filter

### DIFF
--- a/WebVTT-to-SubRip-Converter/GUI/MainForm.cs
+++ b/WebVTT-to-SubRip-Converter/GUI/MainForm.cs
@@ -19,7 +19,7 @@ namespace VttSrtConverter
         {
             OpenFileDialog openFileDialog = new OpenFileDialog
             {
-                Filter = "WebVTT files (*.vtt)|*.vtt",
+                Filter = "WebVTT files (*.vtt)|*.vtt|All files (*.*)|*.*",
                 RestoreDirectory = true,
                 Multiselect = true
             };


### PR DESCRIPTION
For those WebVTT files without `.vtt` filename extension 